### PR TITLE
DEVOPS-587 Update auto-assigned reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -19,8 +19,8 @@ reviewGroups:
     - ronwarner1231
   groupB:
     - babennettdev
-    - connormullett
     - khgriffi259
+    - rvanarsdall
     - tshelton5000
 
 # A number of assignees to add to the pull request


### PR DESCRIPTION
🤖 Beep boop 🤖 

Updating the auto-assigned reviewers to:

- Remove Connor's user
- Add Rob's user
- Make Crash Test Dummies and Blackbird repos share the same reviewer list
