### PR TITLE
DEVOPS-677 Update `setup-node`

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: "Checkout Code"
         uses: actions/checkout@v2
       - name: "Setup Node"
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           registry-url: "https://npm.pkg.github.com/"
           scope: "@polarislabs"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           registry-url: https://npm.pkg.github.com
           scope: "@polarislabs"
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           registry-url: https://registry.npmjs.org
       - name: Switch to the Node version in the .nvmrc
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           registry-url: https://npm.pkg.github.com
           scope: "@polarislabs"


### PR DESCRIPTION
🤖 Updating our `setup-node` Action from v1 to v2.

To prevent an error with v1 of the Action, where it doesn't successfully switch from Node 10 to 12.
