### PR TITLE
DEVOPS-721 - Add a check for an unchanged version

### DIFF
--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -89,3 +89,49 @@ jobs:
               repo: context.repo.repo,
               body: "Please change the version number in the changelog to `x.x.x`. Then Github Actions will update it on PR merge.",
             }).then(() => process.exit(1));
+
+  unchanged-package-version:
+    name: Check for an unchanged version number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check for an unchanged version
+        id: unchanged-version-check
+        continue-on-error: true
+        run: |
+          # Get the commit that `main` was on at the time of branching off
+          BRANCH_POINT=$(git merge-base --fork-point origin/main | cut -c 1-7)
+
+          FILES="
+            package.json
+            package-lock.json
+          "
+
+          # Compare the version numbers, and exit with error if they don't match
+          for FILE in $FILES; do
+            BASE_VERSION=$(git show $BRANCH_POINT:$FILE | jq --raw-output .version)
+            CURRENT_VERSION=$(cat $FILE | jq --raw-output .version)
+
+            if [ "$BASE_VERSION" = "$CURRENT_VERSION" ]; then
+              echo "[INFO] Version number unchanged in the $FILE"
+            else
+              echo "[ERROR] Version numbers don't match:"
+              echo "[ERROR] $BRANCH_POINT:$FILE version: $BASE_VERSION"
+              echo "[ERROR] HEAD:$FILE version:    $CURRENT_VERSION"
+              exit 1
+            fi
+          done
+      - name: Comment
+        if: steps.unchanged-version-check.outcome == 'failure'
+        uses: actions/github-script@v4
+        with:
+          script: |
+            await github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Please check that the version number hasn't been changed in the `package.json` and `package-lock.json`. Github Actions will update it on PR merge.",
+            }).then(() => process.exit(1));

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -133,5 +133,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "Please check that the version number hasn't been changed in the `package.json` and `package-lock.json`. Github Actions will update it on PR merge.",
+              body: "Whoops! The version number has been changed in the `package.json` and/or `package-lock.json`. Please undo your change to the version number. Github Actions will automatically update the package version on PR merge.",
             }).then(() => process.exit(1));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@
 
 ### Features
 
-- JIRA-123: Added this feature.
+- DEVOPS-721: Add a Github Action check that the package version is unchanged.
 
 ### Bug Fixes


### PR DESCRIPTION
Adding a check to the Github Actions, to remind the user to leave the package.json and package-lock.json version unchanged. This will just prevent accidental double-bumps of versions.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖