### PR TITLE
DEVOPS-710 - Delete beta packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,3 +160,15 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  delete-packages:
+    name: Delete beta packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete packages
+        uses: smartsquaregmbh/delete-old-packages@v0.3.2
+        with:
+          version-pattern: "-pr${{ github.event.number }}-"
+          names: ${{ github.event.repository.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@
 
 ### Features
 
-- JIRA-123: Added this feature.
+- DEVOPS-710: Add a Github Action to delete package betas on PR close or merge.
 
 ### Bug Fixes


### PR DESCRIPTION
Adding an extra job to the release.yml to delete the package betas on PR merge or close. I'm using a third-party Action, but not giving it access to the checked-out code, and also restricting its permissions to just the packages.

For the regex to find which packages to delete, I'm using the PR number that was added to the package tag in DEVOPS-715 (in the form `-pr7-`).

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖