### PR TITLE
DEVOPS-715 - Auto-publish package betas

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -4,17 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "src/**"
-      - "**.js"
-      - "**.json"
-  push:
-    branches:
-      - main
-    paths:
-      - "src/**"
-      - "**.js"
-      - "**.json"
 
 env:
   NODE_ENV: development
@@ -44,3 +33,66 @@ jobs:
         run: npm run lint
       - name: Test
         run: npm test
+      - name: Set environment variables
+        id: set-env-vars
+        run: |
+          COMMIT=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7)
+          PR=pr${{ github.event.number }}
+          VERSION=$(jq --raw-output .version package.json)
+
+          # Make a package number in the format: 0.1.0-pr1-abcd123
+          TAG=$VERSION-$PR-$COMMIT
+
+          # Set step outputs, to reference later in the job outputs.
+          echo "::set-output name=commit::$COMMIT"
+          echo "::set-output name=dist-tag::$PR"
+          echo "::set-output name=tag::$TAG"
+      - name: Publish beta package
+        run: |
+          # Bump the version in the package.json and package-lock.json, but don't commit it.
+          npm version --no-git-tag-version ${{ steps.set-env-vars.outputs.tag }}
+
+          # Then publish the tag and dist-tag to Github Packages.
+          echo "Publishing with:"
+          echo "  tag: ${{ steps.set-env-vars.outputs.tag }}"
+          echo "  dist-tag: ${{ steps.set-env-vars.outputs.dist-tag }}"
+
+          npm publish --tag ${{ steps.set-env-vars.outputs.dist-tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Set outputs at the job level, to reference in other jobs.
+    outputs:
+      commit: ${{ steps.set-env-vars.outputs.commit }}
+      dist-tag: ${{ steps.set-env-vars.outputs.dist-tag }}
+      tag: ${{ steps.set-env-vars.outputs.tag }}
+
+  comment:
+    name: Comment with the beta package info
+    runs-on: ubuntu-latest
+    needs: code-checks
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Code Checks just completed successfully
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Code Checks just completed successfully, and a beta package was published. 🎉
+
+            The code at commit ${{ needs.code-checks.outputs.commit }} was published with the tag `${{ needs.code-checks.outputs.tag }}` and the dist-tag `${{ needs.code-checks.outputs.dist-tag }}`.
+
+            You can install this beta and all others auto-published in this PR by referring to the dist-tag:
+
+            ```
+            npm install @${{ github.repository }}@${{ needs.code-checks.outputs.dist-tag }}
+            ```
+          edit-mode: replace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
-- JIRA-123: Added this feature.
+- DEVOPS-715: Auto-publish a beta package whenever Code Checks completes successfully.
+- Make Code Checks run only on a `pull_request` event, and for any file change.
 
 ### Bug Fixes


### PR DESCRIPTION
Adding some extra steps to publish a beta package whenever the Code Checks pass, and then comment with info on how to consume that beta package in other repos. It will update the comment too on each successful publish, and thankfully it looks like that doesn't trigger a Github notification, so we shouldn't be spammed with emails.

I'm using a third-party Action, but doing two things to prevent a malicious Action from harming us:
  - I'm confining it to its own job, so it doesn't have access to the checked-out files.
  - Also giving it limited access to modify the current PR (`jobs.comment.permissions.pull-requests: write`).
This seems like a better security/usability balance to me. Allows us to benefit from the nice third-party Actions that exist, without giving them access to our whole codebase on each run.

I was having trouble at first getting Actions to run when I was just changing a yaml file, so I removed the path filters. I'm comfortable with it running consistently on every push, myself.

I also removed the `on.push` trigger, so it won't run on pushes to the main branch. I think we just want it to run on pushes to a PR, but let me know if there are any issues with that.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖