### PR TITLE
DEVOPS-710 - Delete beta packages

### DIFF
--- a/.github/workflows/delete-betas.yml
+++ b/.github/workflows/delete-betas.yml
@@ -1,0 +1,10 @@
+name: Delete Betas
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-beta:
+    uses: polarislabs/github-actions/.github/workflows/delete-beta-packages.yml@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
-- JIRA-123: Added this feature.
+- DEVOPS-710:
+  - Delete beta packages when a PR is closed.  Uses a reusable workflow from `polarislabs/github-actions` repository
 
 ### Bug Fixes


### PR DESCRIPTION
Adding an extra github action to delete the package betas on PR merge or close.

For the regex to find which packages to delete, I'm using the PR number that was added to the package tag in DEVOPS-715 (in the form `-pr7-`).

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖