### PR TITLE
Escape singlequotes in column comments

### DIFF
--- a/src/funcs/getColumnSettings.js
+++ b/src/funcs/getColumnSettings.js
@@ -21,7 +21,7 @@ module.exports = function getColumnSettings(col) {
   const notNullSetting = !isNullable && 'not null';
   if (notNullSetting) columnSettings.unshift(notNullSetting);
 
-  const note = columnComment && `note: '${columnComment}'`;
+  const note = columnComment && `note: '${columnComment.replace(/'/g, "\\'")}'`;
   if (note) columnSettings.unshift(note);
 
   return columnSettings.length > 0 ? `[${columnSettings.join(', ')}]` : '';


### PR DESCRIPTION
Hey, I have a column with a single quote in its comment, which got rendered as something like:

```dbml
Table "foo" {
        "fooId" bigint  [note: 'Ain't got no foo', primary key]
}
```

This was rejected by `dbdocs`'s parser, but escaping it fixed it.