### PR TITLE
Add support for extracting referenced enum types

### DIFF
--- a/src/funcs/getColumnDefinition.js
+++ b/src/funcs/getColumnDefinition.js
@@ -1,7 +1,7 @@
 const getColumnType = require('./getColumnType');
 const getColumnSettings = require('./getColumnSettings');
 
-module.exports = function getColumnDefinition(col) {
+module.exports = function getColumnDefinition(col, primaryKeys) {
   const { character_maximum_length: charMaxLength, column_name: columnName } = col;
 
   const dataType = getColumnType(col);

--- a/src/funcs/getColumnType.js
+++ b/src/funcs/getColumnType.js
@@ -1,6 +1,6 @@
 // NOTE: possible to use https://www.dbml.org/js-module/#api for the transform to dbml?
 module.exports = function getColumnType(col) {
-  const { data_type: dataType } = col;
+  const { data_type: dataType, udt_name: udtName } = col;
   let columnType;
   switch (dataType) {
     case 'character varying':
@@ -16,6 +16,8 @@ module.exports = function getColumnType(col) {
     case 'time without time zone':
       columnType = 'timestamp';
       break;
+    case 'USER-DEFINED':
+      return udtName;
     default:
       columnType = dataType;
   }

--- a/src/funcs/getDbSchemaStructures.js
+++ b/src/funcs/getDbSchemaStructures.js
@@ -1,6 +1,7 @@
 const getSchemas = require('../queries/getSchemas');
 const getTablesInSchema = require('../queries/getTablesInSchema');
 const getTableStructure = require('../queries/getTableStructure');
+const getReferencedEnums = require('../queries/getReferencedEnums');
 const getConstraints = require('../queries/getConstraints');
 
 const getPrimaryKey = (schema, tableName, constraints) => {
@@ -81,9 +82,12 @@ module.exports = async function getDbSchemaStructures(argv) {
   const getAllColumnDefs = allTables.map(async ({ constraints, schema, tables }) => {
     const allTableStructures = await getTableStructuresForSchema({ constraints, schema, tables });
 
+    const enums = await getReferencedEnums({ schema, allTableStructures });
+
     return {
       constraints,
       schema,
+      enums,
       tables: allTableStructures
     };
   });

--- a/src/funcs/transformEnumToDBML.js
+++ b/src/funcs/transformEnumToDBML.js
@@ -5,7 +5,7 @@ module.exports = function transformEnumToDBML(
   schemaName,
   includeSchemaName
 ) {
-  // It seems like DBML doesn't support a comment on the enum itself, so the comment isn't used for now
+  // It seems like dbdocs.io doesn't support a comment on the enum itself, so the comment isn't used for now
 
   const enumNameString = includeSchemaName ? `${schemaName}.${name}` : name;
 

--- a/src/funcs/transformEnumToDBML.js
+++ b/src/funcs/transformEnumToDBML.js
@@ -7,9 +7,9 @@ module.exports = function transformEnumToDBML(
 ) {
   // It seems like dbdocs.io doesn't support a comment on the enum itself, so the comment isn't used for now
 
-  const enumNameString = includeSchemaName ? `${schemaName}.${name}` : name;
+  const enumNameString = includeSchemaName ? `"${schemaName}"."${name}"` : `"${name}"`;
 
-  return `Enum "${enumNameString}" {${EOL}\t${values
+  return `Enum ${enumNameString} {${EOL}\t${values
     .map(value => `"${value}"`)
     .join(`${EOL}\t`)}${EOL}}${EOL}${EOL}`;
 };

--- a/src/funcs/transformEnumToDBML.js
+++ b/src/funcs/transformEnumToDBML.js
@@ -1,0 +1,15 @@
+const { EOL } = require('os');
+
+module.exports = function transformEnumToDBML(
+  { name, comment, values },
+  schemaName,
+  includeSchemaName
+) {
+  // It seems like DBML doesn't support a comment on the enum itself, so the comment isn't used for now
+
+  const enumNameString = includeSchemaName ? `${schemaName}.${name}` : name;
+
+  return `Enum "${enumNameString}" {${EOL}\t${values
+    .map(value => `"${value}"`)
+    .join(`${EOL}\t`)}${EOL}}${EOL}${EOL}`;
+};

--- a/src/funcs/writeResults.js
+++ b/src/funcs/writeResults.js
@@ -3,6 +3,7 @@ const path = require('path');
 const yargs = require('yargs');
 
 const transformTableStructureToDBML = require('./transformTableStructureToDBML');
+const transformEnumToDBML = require('./transformEnumToDBML');
 const transformFKsToRefsDBML = require('./transformFKsToRefsDBML');
 
 const createFile = require('../utils/createFile');
@@ -45,7 +46,7 @@ module.exports = schemaStructures => {
 
   const columnGetter = getColumnGetter(schemaStructures);
 
-  return schemaStructures.forEach(({ constraints, schema, tables }) => {
+  return schemaStructures.forEach(({ constraints, schema, tables, enums }) => {
     if (splitDbmlBySchema) {
       filePathWithName = getFileName({
         dbName,
@@ -56,6 +57,11 @@ module.exports = schemaStructures => {
 
       createFile(filePathWithName);
     }
+
+    enums.forEach(enumDefinition => {
+      const dbml = transformEnumToDBML(enumDefinition, schema, includeSchemaName);
+      writeToFile(filePathWithName, dbml);
+    });
 
     tables.forEach(tableDefinition => {
       const dbml = transformTableStructureToDBML(tableDefinition, schema, includeSchemaName);

--- a/src/queries/getReferencedEnums.js
+++ b/src/queries/getReferencedEnums.js
@@ -1,0 +1,29 @@
+const db = require('../db');
+
+module.exports = async function getReferencedEnums({ schema, allTableStructures }) {
+  const referencedUdtNames = [
+    ...new Set(
+      allTableStructures.flatMap(({ structure }) =>
+        structure
+          .filter(column => column.data_type === 'USER-DEFINED')
+          .map(column => column.udt_name)
+      )
+    )
+  ];
+  if (referencedUdtNames.length === 0) {
+    return [];
+  }
+
+  const enumInfoQuery = (schemaName, typeNames) => `select t.typname as name,
+    pg_catalog.obj_description(enumtypid) as comment,
+    array_agg(e.enumlabel::text) as values
+    from pg_type t
+    left join pg_enum e on t.oid = e.enumtypid
+    join pg_catalog.pg_namespace n on n.oid = t.typnamespace
+    where n.nspname = '${schemaName}' and t.typcategory = 'E' and t.typname in (${typeNames.map(
+    typeName => `'${typeName}'`
+  )}) group by 1, 2`;
+
+  const { rows } = await db.client.query(enumInfoQuery(schema, referencedUdtNames));
+  return rows;
+};


### PR DESCRIPTION
The DB schema I'm working with is using a lot of enum types. When I ran `pg-to-dbml` on it, all of those came out as `USER-DEFINED` in the dbml output.

This adds support for extracting the enum values from all referenced enums and rendering them as DBML. For example:

```sql
CREATE SCHEMA myschema;
SET search_path TO 'myschema';
CREATE TYPE my_enum AS ENUM('foo', 'bar', 'quux');
CREATE TABLE my_things (thing_id BIGINT, status my_enum);
```

This comes out as:

```
Enum "my_enum" {
        "bar"
        "foo"
        "quux"
}

Table "my_things" {
        "thing_id" bigint   
        "status" my_enum   
 } 
```

I tested it with dbdocs, which does pick it up nicely: https://dbdocs.io/andreas.lind/myschema?table=my_things&schema=public&view=table_structure

![Screenshot 2022-03-15 at 08 39 52](https://user-images.githubusercontent.com/373545/158329352-9a6dd916-efc8-47b4-aefc-86c6c62673d5.png)

Note: Postgres does not support comments on enum _values_ (even though DBML does). Postgres and DBML _do_ support comments on types. However, I couldn't get dbinfo.io to accept the syntax, so I've left that out for now 😇 