### PR TITLE
DEVOPS-895 - Fix NVM in our Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,13 +118,11 @@ jobs:
         with:
           ref: main
       - name: Use Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
+          node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org
           scope: "@polarislabs"
-      - name: Switch to the Node version in the .nvmrc
-        shell: bash -l {0}
-        run: nvm install
       - name: Install dependencies
         run: npm ci
         env:
@@ -145,13 +143,11 @@ jobs:
         with:
           ref: main
       - name: Use Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
+          node-version-file: ".nvmrc"
           registry-url: https://npm.pkg.github.com
           scope: "@polarislabs"
-      - name: Switch to the Node version in the .nvmrc
-        shell: bash -l {0}
-        run: nvm install
       - name: Install dependencies
         run: npm ci
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@
 
 ### Features
 
-- JIRA-123: Added this feature.
+- DEVOPS-895: Fix NVM in our Github Actions.
 
 ### Bug Fixes


### PR DESCRIPTION
Update `setup-node` to v3.
Use new `node-version-file` option to read the version from the `.nvmrc`.

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖