### PR TITLE
Allow specifying the database name as part of the connection string

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,11 +1,13 @@
 const { Client } = require('pg');
 
 let client;
-let databaseName;
 
 async function initialize({ dbConnectionString, dbName }) {
-  databaseName = dbName;
-  const connectionString = `${dbConnectionString}/${dbName}`;
+  let connectionString = dbConnectionString;
+  if (dbName) {
+    // Add the database name to the connection string, while tolerating a trailing slash:
+    dbConnectionString = connectionString.replace(/\/?$/, `/${dbName}`);
+  }
 
   client = new Client({
     connectionString
@@ -19,7 +21,7 @@ module.exports = {
     return client;
   },
   get dbName() {
-    return databaseName;
+    return client.connectionParameters.database;
   },
   initialize
 };

--- a/src/funcs/writeResults.js
+++ b/src/funcs/writeResults.js
@@ -7,6 +7,7 @@ const transformFKsToRefsDBML = require('./transformFKsToRefsDBML');
 
 const createFile = require('../utils/createFile');
 const writeToFile = require('../utils/writeToFile');
+const db = require('../db');
 
 const getFileName = ({ dbName, dir, schema, splitDbmlBySchema }) => {
   const fileName = splitDbmlBySchema ? `${dbName}.${schema}` : dbName;
@@ -27,7 +28,8 @@ const getColumnGetter = schemas => (schemaName, tableName, ordinalPosition) => {
 };
 
 module.exports = schemaStructures => {
-  const { db: dbName, o: outputDir, separate_dbml_by_schema: splitDbmlBySchema } = yargs.argv;
+  const { o: outputDir, separate_dbml_by_schema: splitDbmlBySchema } = yargs.argv;
+  const { dbName } = db;
   const dir = outputDir || './';
 
   const includeSchemaName = schemaStructures.length > 1 && !splitDbmlBySchema;


### PR DESCRIPTION
In my opinion it's more handy to specify the database name as part of the connection string, eg `pg-to-dbml -c pg://localhost/my_db_name` than having to do it with a separate `--db` switch.

I would go as far as to suggest removing the `--db` switch altogether, but I implemented so it's backwards compatibly this time around 😇 