### PR TITLE
Clean up the .dbml output

### DIFF
--- a/src/funcs/transformFKsToRefsDBML.js
+++ b/src/funcs/transformFKsToRefsDBML.js
@@ -38,5 +38,5 @@ module.exports = function transformFKsToRefsDBML(
     .sort()
     .join(``);
 
-  return `${dbml} ${EOL} ${EOL}`;
+  return `${dbml}${EOL}${EOL}`;
 };

--- a/src/funcs/transformFKsToRefsDBML.js
+++ b/src/funcs/transformFKsToRefsDBML.js
@@ -35,6 +35,7 @@ module.exports = function transformFKsToRefsDBML(
 
       return `${EOL}Ref: ${fromString}.${foreignKey.column_name} > ${toString}.${foreignRelation.column_name}`;
     })
+    .sort()
     .join(``);
 
   return `${dbml} ${EOL} ${EOL}`;

--- a/src/funcs/transformTableStructureToDBML.js
+++ b/src/funcs/transformTableStructureToDBML.js
@@ -14,7 +14,7 @@ module.exports = function transformTableStructureToDBML(
     columnDefinitions.push('', `  note: '${comment.replace(/'/g, "\\'")}'`);
   }
 
-  columnDefinitions.push(`} ${EOL} ${EOL} `);
+  columnDefinitions.push(`}${EOL}${EOL}`);
 
-  return columnDefinitions.join(`${EOL} `);
+  return columnDefinitions.join(`${EOL}`);
 };


### PR DESCRIPTION
This PR does some tidying up on the resulting .dbml file output:

1. The foreign key references listed in the bottom of a generated .dbml file are sorted alphabetically _also in terms of which columns they relate to_
2. The generated .dbml file no longer contains trailing whitespace at the end of lines